### PR TITLE
Update 99_00_references.Rmd

### DIFF
--- a/99_00_references.Rmd
+++ b/99_00_references.Rmd
@@ -1,2 +1,8 @@
 
 `r if (knitr::is_latex_output()) {cat("# References {-}")}`
+
+
+```{block, type='invisible'}
+Workaround for hiding end of book references for HTML
+<div id="refs"></div>
+```


### PR DESCRIPTION
There is no bookdown configuration for hiding the references section. Using the invisible block to do it.